### PR TITLE
Switch bridge to non-blocking DRAMSys access

### DIFF
--- a/src/AxiToTlmBridge.cpp
+++ b/src/AxiToTlmBridge.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <iomanip>
 #include <cassert>
+#include <utility>
 
 AxiToTlmBridge::AxiToTlmBridge(sc_core::sc_module_name name, std::size_t data_width_bytes)
     : sc_module(name)
@@ -16,6 +17,9 @@ AxiToTlmBridge::AxiToTlmBridge(sc_core::sc_module_name name, std::size_t data_wi
     tlm_initiator_socket(*this);
     // Worker for nb_transport requests
     SC_THREAD(process_axi_reqs);
+    SC_METHOD(process_completions);
+    sensitive << completion_queue_.default_event();
+    dont_initialize();
 }
 
 void AxiToTlmBridge::before_end_of_elaboration() {
@@ -29,6 +33,10 @@ void AxiToTlmBridge::process_axi_reqs() {
         auto* gp = req_fifo_.read();
         assert(gp != nullptr);
 
+        auto ctx_uptr = std::make_unique<RequestContext>();
+        auto* ctx = ctx_uptr.get();
+        ctx->original = gp;
+
         // Accept any AXI burst type; if extensions are absent or burst is FIXED/WRAP, fall back to data_length
         std::size_t total_bytes = gp->get_data_length();
         if (total_bytes == 0) {
@@ -37,6 +45,7 @@ void AxiToTlmBridge::process_axi_reqs() {
             auto beat_bytes = axi::get_burst_size(*gp);
             total_bytes = static_cast<std::size_t>(total_beats) * static_cast<std::size_t>(beat_bytes);
         }
+        ctx->total_bytes = total_bytes;
 
         const auto base_addr = gp->get_address();
         auto* base_ptr = gp->get_data_ptr();
@@ -61,6 +70,14 @@ void AxiToTlmBridge::process_axi_reqs() {
             SC_REPORT_INFO("AxiToTlmBridge", oss.str().c_str());
         }
 
+        active_reqs_.emplace(gp, std::move(ctx_uptr));
+
+        if (total_bytes == 0) {
+            ctx->all_dispatched = true;
+            finalize_request(ctx);
+            continue;
+        }
+
         if (get_base_latency() != sc_core::SC_ZERO_TIME) wait(get_base_latency());
 
         const std::size_t dr_beat = std::max<std::size_t>(1, get_downstream_beat_bytes());
@@ -79,42 +96,34 @@ void AxiToTlmBridge::process_axi_reqs() {
             sub->set_dmi_allowed(false);
             sub->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
 
-            // Register event and start AT request
-            auto* ev = new sc_core::sc_event();
-            pending_resp_[sub] = ev;
+            // Track outstanding downstream transaction and start AT request
+            ctx->outstanding++;
+            pending_sub_[sub] = ctx;
             tlm::tlm_phase sub_ph = tlm::BEGIN_REQ;
             sc_core::sc_time sub_dly = sc_core::SC_ZERO_TIME;
             auto stat = tlm_initiator_socket->nb_transport_fw(*sub, sub_ph, sub_dly);
-            (void)stat;
 
-            // Wait until BEGIN_RESP observed in nb_transport_bw
-            wait(*ev);
-
-            if (get_beat_latency() != sc_core::SC_ZERO_TIME) wait(get_beat_latency());
-
-            if (!sub->is_response_ok()) {
-                gp->set_response_status(sub->get_response_status());
-                // cleanup
-                pending_resp_.erase(sub);
-                delete ev;
-                sub->release();
-                break;
+            if (stat == tlm::TLM_UPDATED) {
+                if (sub_ph == tlm::BEGIN_RESP) {
+                    schedule_completion(*sub, sub_dly);
+                }
+                // ignore END_REQ updates as we already consider the request accepted
+            } else if (stat == tlm::TLM_COMPLETED) {
+                schedule_completion(*sub, sub_dly);
             }
 
-            // cleanup
-            pending_resp_.erase(sub);
-            delete ev;
-            sub->release();
-
             done += chunk;
+
+            if (get_beat_latency() != sc_core::SC_ZERO_TIME && done < total_bytes) {
+                wait(get_beat_latency());
+            }
         }
+        ctx->all_dispatched = true;
 
-        if (done == total_bytes) gp->set_response_status(tlm::TLM_OK_RESPONSE);
-
-        // Notify initiator via backward path (BEGIN_RESP)
-        tlm::tlm_phase ph = tlm::BEGIN_RESP;
-        sc_core::sc_time bw_delay = sc_core::SC_ZERO_TIME;
-        (void)axi_target_socket->nb_transport_bw(*gp, ph, bw_delay);
+        // If nothing is outstanding (e.g., immediate completion), finalize now
+        if (ctx->outstanding == 0) {
+            finalize_request(ctx);
+        }
     }
 }
 
@@ -186,12 +195,75 @@ tlm::tlm_sync_enum AxiToTlmBridge::nb_transport_bw(tlm::tlm_generic_payload& tra
                 << ") at " << sc_core::sc_time_stamp();
             SC_REPORT_INFO("AxiToTlmBridge", oss.str().c_str());
         }
-        auto it = pending_resp_.find(&trans);
-        if (it != pending_resp_.end() && it->second) {
-            it->second->notify(delay);
-        }
+        schedule_completion(trans, delay);
         phase = tlm::END_RESP;
         return tlm::TLM_UPDATED;
     }
     return tlm::TLM_ACCEPTED;
+}
+
+void AxiToTlmBridge::schedule_completion(tlm::tlm_generic_payload& trans, const sc_core::sc_time& delay) {
+    completion_fifo_.push_back(&trans);
+    completion_queue_.notify(delay);
+}
+
+void AxiToTlmBridge::process_completions() {
+    if (completion_fifo_.empty()) {
+        return;
+    }
+
+    auto* sub = completion_fifo_.front();
+    completion_fifo_.pop_front();
+
+    auto ctx_it = pending_sub_.find(sub);
+    if (ctx_it == pending_sub_.end() || ctx_it->second == nullptr) {
+        SC_REPORT_WARNING("AxiToTlmBridge", "Received completion for unknown sub-transaction");
+        if (sub != nullptr) {
+            sub->release();
+        }
+        return;
+    }
+
+    auto* ctx = ctx_it->second;
+    pending_sub_.erase(ctx_it);
+
+    if (!sub->is_response_ok()) {
+        ctx->has_error = true;
+        ctx->error_status = sub->get_response_status();
+    }
+
+    ctx->completed_bytes += sub->get_data_length();
+    if (ctx->outstanding > 0) {
+        ctx->outstanding--;
+    }
+
+    sub->release();
+
+    if (ctx->outstanding == 0 && ctx->all_dispatched) {
+        finalize_request(ctx);
+    }
+}
+
+void AxiToTlmBridge::finalize_request(RequestContext* ctx) {
+    if (ctx == nullptr || ctx->original == nullptr) {
+        return;
+    }
+
+    auto req_it = active_reqs_.find(ctx->original);
+    if (req_it == active_reqs_.end()) {
+        return;
+    }
+
+    auto* gp = ctx->original;
+    if (ctx->has_error) {
+        gp->set_response_status(ctx->error_status);
+    } else {
+        gp->set_response_status(tlm::TLM_OK_RESPONSE);
+    }
+
+    tlm::tlm_phase ph = tlm::BEGIN_RESP;
+    sc_core::sc_time bw_delay = sc_core::SC_ZERO_TIME;
+    (void)axi_target_socket->nb_transport_bw(*gp, ph, bw_delay);
+
+    active_reqs_.erase(req_it);
 }


### PR DESCRIPTION
## Summary
- rework `AxiToTlmBridge` to queue downstream completions and respond asynchronously instead of blocking on each beat
- track per-request state so AXI responses are sent once all sub-transactions return, supporting DRAMSys bandwidth reporting

## Testing
- ctest --test-dir build -R bridge_test --output-on-failure

------
https://chatgpt.com/codex/tasks/task_b_68d4ef3432a08326a4a2bef8d8483533